### PR TITLE
Fix failing tests

### DIFF
--- a/tests/explainers/test_kernel.py
+++ b/tests/explainers/test_kernel.py
@@ -106,20 +106,16 @@ def test_kernel_shap_with_a1a_sparse_nonzero_background():
     median = sp.sparse.csr_matrix(median_dense)
     explainer = shap.KernelExplainer(linear_model.predict, median)
     shap_values = explainer.shap_values(x_test)
-    # Compare to dense results
-    x_train_dense = x_train.toarray()
 
     def dense_to_sparse_predict(data):
         sparse_data = sp.sparse.csr_matrix(data)
         return linear_model.predict(sparse_data)
 
-    explainer_dense = shap.KernelExplainer(linear_model.predict, median_dense.reshape((1, len(median_dense))))
+    explainer_dense = shap.KernelExplainer(dense_to_sparse_predict, median_dense.reshape((1, len(median_dense))))
     x_test_dense = x_test.toarray()
     shap_values_dense = explainer_dense.shap_values(x_test_dense)
     # Validate sparse and dense result is the same
-    # Note: The default tolerance is almost always fine, but in one out of every
-    # 20 runs or so it fails so decreasing it by two orders of magnitude from the default
-    assert(np.allclose(shap_values, shap_values_dense, rtol=1e-02, atol=1e-04))
+    assert(np.allclose(shap_values, shap_values_dense, rtol=1e-02, atol=1e-01))
 
 def test_kernel_shap_with_high_dim_sparse():
     # verifies we can run on very sparse data produced from feature hashing


### PR DESCRIPTION
This PR addresses three issues causing failing tests. Two, the use of `DummyRegressor` and `DummyClassifier` in sklearn gradient-boosted ensembles, were originally fixed in https://github.com/slundberg/shap/commit/e9acbb822c3e864b21b4f47437ced294264c0a21#diff-3cf76979f5fa45367b27a80585662c0d and https://github.com/slundberg/shap/commit/96968e4da2798ba4ca7da5bd28e87d83c89c6ce8#diff-3cf76979f5fa45367b27a80585662c0d respectively. These particular fixes contained errors of their own (used `if` where they should have used `elif`), and so instead of cherry-picking those commits I made my own implementing the correct changes.

The third issue, a flaky test checking the equivalence of sparse and dense representations, was fixed in https://github.com/slundberg/shap/commit/86ddf75e6ec4fedcdaa1a34bb2e6c63221ef9be6. As such I cherry-picked that commit wholesale.

These changes can be tested by cloning this repository and running `python setup.py test`.