### PR TITLE
Remove tqdm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ def run_setup(with_binary=True, test_xgboost=True, test_lightgbm=True):
         package_data={'shap': ['tree_shap.h']},
         cmdclass={'build_ext': build_ext},
         setup_requires=['numpy<1.17'],
-        install_requires=['numpy<1.17', 'scipy<1.3', 'scikit-learn<0.21', 'pandas<0.25', 'tqdm'],
+        install_requires=['numpy<1.17', 'scipy<1.3', 'scikit-learn<0.21', 'pandas<0.25'],
         test_suite='nose.collector',
         tests_require=tests_require,
         ext_modules=ext_modules,

--- a/shap/benchmark/measures.py
+++ b/shap/benchmark/measures.py
@@ -1,5 +1,4 @@
 import numpy as np
-from tqdm import tqdm
 import gc
 
 
@@ -40,7 +39,7 @@ def remove(nmask, X_train, y_train, X_test, y_test, attr_test, model_generator, 
     tie_breaking_noise = const_rand(X_train.shape[1]) * 1e-6
     last_nmask = _remove_cache.get("nmask", None)
     last_yp_masked_test = _remove_cache.get("yp_masked_test", None)
-    for i in tqdm(range(len(y_test)), "Retraining for the 'remove' metric"):
+    for i in range(len(y_test)):
         if cache_match and last_nmask[i] == nmask[i]:
             yp_masked_test[i] = last_yp_masked_test[i]
         elif nmask[i] == 0:
@@ -159,7 +158,7 @@ def keep(nkeep, X_train, y_train, X_test, y_test, attr_test, model_generator, me
     tie_breaking_noise = const_rand(X_train.shape[1]) * 1e-6
     last_nkeep = _keep_cache.get("nkeep", None)
     last_yp_masked_test = _keep_cache.get("yp_masked_test", None)
-    for i in tqdm(range(len(y_test)), "Retraining for the 'keep' metric"):
+    for i in range(len(y_test)):
         if cache_match and last_nkeep[i] == nkeep[i]:
             yp_masked_test[i] = last_yp_masked_test[i]
         elif nkeep[i] == attr_test.shape[1]:

--- a/shap/explainers/kernel.py
+++ b/shap/explainers/kernel.py
@@ -9,7 +9,6 @@ import itertools
 import warnings
 from sklearn.linear_model import LassoLarsIC, Lasso, lars_path
 from sklearn.cluster import KMeans
-from tqdm import tqdm
 from .explainer import Explainer
 
 log = logging.getLogger('shap')
@@ -202,7 +201,7 @@ class KernelExplainer(Explainer):
         # explain the whole dataset
         elif len(X.shape) == 2:
             explanations = []
-            for i in tqdm(range(X.shape[0]), disable=kwargs.get("silent", False)):
+            for i in range(X.shape[0]):
                 data = X[i:i + 1, :]
                 if self.keep_index:
                     data = convert_to_instance_with_index(data, column_name, index_value[i:i + 1], index_name)

--- a/shap/explainers/linear.py
+++ b/shap/explainers/linear.py
@@ -1,6 +1,5 @@
 import numpy as np
 import warnings
-from tqdm import tqdm
 from .explainer import Explainer
 
 class LinearExplainer(Explainer):
@@ -125,7 +124,7 @@ class LinearExplainer(Explainer):
         mean_transform = np.zeros((M,M))
         x_transform = np.zeros((M,M))
         inds = np.arange(M, dtype=np.int)
-        for _ in tqdm(range(nsamples), "Estimating transforms"):
+        for _ in range(nsamples):
             np.random.shuffle(inds)
             cov_inv_SiSi = np.zeros((0,0))
             cov_Si = np.zeros((M,0))


### PR DESCRIPTION
This PR removes `tqdm`, a package which added a progress meter to the `shap` command-line output. To be merged after https://github.com/Shopify/shap/pull/2.

To tophat this change, I used the below script to run the `KernelExplainer` on both master and this branch: 

<details>
<summary> run_kernel.py </summary>

```
import argparse
import numpy as np
import shap
from sklearn.linear_model import LogisticRegression

np.random.seed(24)
X_train = np.random.randint(low=-100, high=101, size=(15, 20))
X_test = np.random.randint(low=-100, high=101, size=(5, 20))
y_train = np.random.randint(low=0, high=2, size=15)
model = LogisticRegression(random_state=42)
model.fit(X_train, y_train)

explainer = shap.KernelExplainer(model.predict_proba, X_train, nsamples=100, link='logit')

parser = argparse.ArgumentParser()
parser.add_argument('filename', type=str, nargs=1)
filename = parser.parse_args().filename[0]

with open(filename, 'wb') as out_file:
    np.save(out_file, explainer.shap_values(X_test))
```

</details> 

I then ran it on both branches, reinstalling all packages from a clean slate beforehand:

```
$ git checkout master
$ rm -rf .eggs && pip uninstall -y -r <(pip freeze)
$ python setup.py install
$ python run_kernel.py old_values.txt
$ git checkout remove-tqdm
$ rm -rf .eggs && pip uninstall -y -r <(pip freeze)
$ python setup.py install
$ python run_kernel.py new_values.txt
```

I then reconciled the two results:

```
import numpy as np
old_values = np.load('old_values.txt')
new_values = np.load('new_values.txt')
np.allclose(old_values, new_values, rtol=1e-09, atol=1e-09)
```

All values were well within 10^-09 of their counterparts, with slight deviations to be expected due to the stochasticity of logistic regression. 

The same script and approach was used to 🎩 `LinearExplainer` (by changing the explainer from kernel to linear), also returning no discrepancies between branches.