### PR TITLE
Differentiate version and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ pip install shap
 conda install -c conda-forge shap
 </pre>
 
+## Development
+
+To install SHAP in a development environment, simply clone this repo and run `python setup.py install`.
+Python 2.7.x is required, as well as a recent version of `setuptools`.
+
+To run the test suite, run `python setup.py test`. Note that tests for `lightbm` will fail unless `libomp` is installed.
+You can install this via `brew install libomp` on MacOS.
+
 ## Tree ensemble example with TreeExplainer (XGBoost/LightGBM/CatBoost/scikit-learn models)
 
 While SHAP values can explain the output of any machine learning model, we have developed a high-speed exact algorithm for tree ensemble methods ([Tree SHAP arXiv paper](https://arxiv.org/abs/1802.03888)). Fast C++ implementations are supported for *XGBoost*, *LightGBM*, *CatBoost*, and *scikit-learn* tree models:

--- a/shap/__init__.py
+++ b/shap/__init__.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 
-__version__ = '0.28.5'
+__version__ = '0.28.5.post1'
 
 from .explainers.kernel import KernelExplainer, kmeans
 from .explainers.sampling import SamplingExplainer


### PR DESCRIPTION
This PR changes the version number to `0.28.5s` to differentiate it from the mainline `shap` package when debugging installation environments. The README is also updated with details on setting up the development environment.